### PR TITLE
ci: pin GitHub Actions to SHA and bump to latest versions

### DIFF
--- a/.github/workflows/sync-sig-auth-project.yml
+++ b/.github/workflows/sync-sig-auth-project.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: '1.19'
     - name: Sync sig-auth project board - kubernetes org


### PR DESCRIPTION
Pin actions/checkout and actions/setup-go to full-length commit SHAs to comply with kubernetes-sigs org policy. Bump both actions from v3 to latest (checkout v6.0.2, setup-go v6.4.0).